### PR TITLE
LABEL= and UUID= support

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,8 +14,8 @@ source=('growpart'
         'growfs-hook'
         'growfs-install')
 sha256sums=('13428ca6e335176d5ebfd30027f3a4dbc9b8054e6d49f631f87aae55d9ffcb8c'
-            '69dcb1143dd84d1f7a834bac58e7fb03c28f63cf588a25bb1c444fb1ebef828e'
-            '656083022534ea34e10926bd63a7efad5a56dbaa5fcb569c2df0201b57a4cd39')
+            '6dd272462b036a39eb3175e5a34624e91e42a23b29f0671cb84639f6fee6ede4'
+            'b8820708d36e4e30a0493474f3b64d3eef5b42ceec4b1781832246c2ff07c462')
 package() {
     install -m755 -d "${pkgdir}/usr/bin"
     install -m755 "${srcdir}/growpart" "${pkgdir}/usr/bin/growpart"

--- a/growfs-hook
+++ b/growfs-hook
@@ -9,8 +9,21 @@ run_hook() {
     [ -f "${rootmnt}$f" ] && echo "GrowRootFS: disabled by file" && return 0
   done
 
+  # Resolve UUID= / LABEL=
+  case ${root} in
+    UUID=*)
+      rootpath=$(findfs ${root})
+      ;;
+    LABEL=*)
+      rootpath=$(findfs ${root})
+      ;;
+    *)
+      rootpath=${root}
+      ;;
+  esac
+
   # figure out what disk '$root' is on
-  { [ ! -L "${root}" ] && rootdev=${root} || rootdev=$(readlink -f "${root}") ; } || { echo "failed to get target of link for ${root}" && 
+  { [ ! -L "${rootpath}" ] && rootdev=${rootpath} || rootdev=$(readlink -f "${rootpath}") ; } || { echo "failed to get target of link for ${rootpath}" && 
 return 0 ; }
 
   case "${rootdev}" in

--- a/growfs-install
+++ b/growfs-install
@@ -2,6 +2,7 @@
 
 build() {
     add_binary date
+    add_binary findfs
     add_binary growpart
     add_binary resize2fs
     add_binary sfdisk


### PR DESCRIPTION
This allows for when the bootloader passes a `LABEL=` or `UUID=` root filesystem identifier to the kernel.